### PR TITLE
chapter6.5 프로퍼티를 이용한 객체 관리

### DIFF
--- a/src/main/java/bind/ServletRequestDataBinder.java
+++ b/src/main/java/bind/ServletRequestDataBinder.java
@@ -13,7 +13,7 @@ public class ServletRequestDataBinder {
         }
 
         Set<String> paramNames = request.getParameterMap().keySet();
-        Object dataObject = dataType.newInstance();
+        Object dataObject = dataType.getConstructor().newInstance();
         Method m = null;
 
         for (String paramName : paramNames) {

--- a/src/main/java/context/ApplicationContext.java
+++ b/src/main/java/context/ApplicationContext.java
@@ -1,0 +1,70 @@
+package context;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import java.io.FileReader;
+import java.lang.reflect.Method;
+import java.util.Hashtable;
+import java.util.Properties;
+
+public class ApplicationContext {
+    Hashtable<String, Object> objTable = new Hashtable<>();
+
+    public Object getBean(String key) {
+        return objTable.get(key);
+    }
+
+    public ApplicationContext(String propertiesPath) throws Exception {
+        Properties props = new Properties();
+        props.load(new FileReader(propertiesPath));
+
+        prepareObjects(props);
+        injectDependency();
+    }
+
+    private void prepareObjects(Properties props) throws Exception {
+        Context ctx = new InitialContext();
+        String key = null;
+        String value = null;
+
+        for (Object item : props.keySet()) {
+            key = (String) item;
+            value = props.getProperty(key);
+            if (key.startsWith("jndi.")) {
+                objTable.put(key, ctx.lookup(value));
+            } else {
+                objTable.put(key, Class.forName(value).getConstructor().newInstance());
+            }
+        }
+    }
+
+    private void injectDependency() throws Exception {
+        for (String key : objTable.keySet()) {
+            if (!key.startsWith("jndi.")) {
+                callSetter(objTable.get(key));
+            }
+        }
+    }
+
+    private void callSetter(Object obj) throws Exception {
+        Object dependency = null;
+        for (Method m : obj.getClass().getMethods()) {
+            if (m.getName().startsWith("set")) {
+                dependency = findObjectByType(m.getParameterTypes()[0]);
+                if (dependency != null) {
+                    m.invoke(obj, dependency);
+                }
+            }
+        }
+    }
+
+    private Object findObjectByType(Class<?> type) {
+        for (Object obj : objTable.values()) {
+            if (type.isInstance(obj)) {
+                return obj;
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/listeners/ContextLoaderListener.java
+++ b/src/main/java/listeners/ContextLoaderListener.java
@@ -1,5 +1,6 @@
 package listeners;
 
+import context.ApplicationContext;
 import controls.*;
 import dao.MySqlMemberDao;
 
@@ -12,24 +13,19 @@ import javax.sql.DataSource;
 
 @WebListener
 public class ContextLoaderListener implements ServletContextListener {
+    static ApplicationContext applicationContext;
+
+    public static ApplicationContext getApplicationContext() {
+        return applicationContext;
+    }
 
     @Override
     public void contextInitialized(ServletContextEvent event){
         try {
             ServletContext sc = event.getServletContext();
 
-            InitialContext initialContext = new InitialContext();
-            DataSource ds = (DataSource) initialContext.lookup("java:comp/env/jdbc/studydb");
-
-            MySqlMemberDao memberDao = new MySqlMemberDao();
-            memberDao.setDataSource(ds);
-
-            sc.setAttribute("/auth/login.do", new LogInController().setMemberDao(memberDao));
-            sc.setAttribute("/auth/logout.do", new LogOutController());
-            sc.setAttribute("/member/list.do", new MemberListController().setMemberDao(memberDao));
-            sc.setAttribute("/member/update.do", new MemberUpdateController().setMemberDao(memberDao));
-            sc.setAttribute("/member/delete.do", new MemberDeleteController().setMemberDao(memberDao));
-            sc.setAttribute("/member/add.do", new MemberAddController().setMemberDao(memberDao));
+            String propertiesPath = sc.getRealPath(sc.getInitParameter("contextConfigLocation"));
+            applicationContext = new ApplicationContext(propertiesPath);
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/servlets/DispatcherServlet.java
+++ b/src/main/java/servlets/DispatcherServlet.java
@@ -13,7 +13,9 @@ import javax.servlet.http.HttpServletResponse;
 
 import bind.DataBinding;
 import bind.ServletRequestDataBinder;
+import context.ApplicationContext;
 import controls.*;
+import listeners.ContextLoaderListener;
 import vo.Member;
 
 @SuppressWarnings("serial")
@@ -24,10 +26,16 @@ public class DispatcherServlet extends HttpServlet {
         response.setContentType("text/html; charset=UTF-8");
         String servletPath = request.getServletPath();
         try {
-            ServletContext sc = this.getServletContext();
+            ApplicationContext ctx = ContextLoaderListener.getApplicationContext();
+
             HashMap<String, Object> model = new HashMap<String, Object>();
             model.put("session", request.getSession());
-            Controller pageController = (Controller) sc.getAttribute(servletPath);
+
+            Controller pageController = (Controller) ctx.getBean(servletPath);
+
+            if (pageController == null) {
+                throw new Exception("요청한 서비스를 찾을 수 없습니다.");
+            }
 
             if (pageController instanceof DataBinding) {
                 prepareRequestData(request, model, (DataBinding)pageController);

--- a/web/WEB-INF/application-context.properties
+++ b/web/WEB-INF/application-context.properties
@@ -1,0 +1,8 @@
+jndi.dataSource=java:comp/env/jdbc/studydb
+memberDao=dao.MySqlMemberDao
+/auth/login.do=controls.LogInController
+/auth/logout.do=controls.LogOutController
+/member/list.do=controls.MemberListController
+/member/add.do=controls.MemberAddController
+/member/update.do=controls.MemberUpdateController
+/member/delete.do=controls.MemberDeleteController

--- a/web/WEB-INF/web.xml
+++ b/web/WEB-INF/web.xml
@@ -4,6 +4,11 @@
          xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
          version="4.0">
 
+    <context-param>
+        <param-name>contextConfigLocation</param-name>
+        <param-value>/WEB-INF/application-context.properties</param-value>
+    </context-param>
+
     <resource-ref>
         <res-ref-name>jdbc/studydb</res-ref-name>
         <res-type>javax.sql.DataSource</res-type>


### PR DESCRIPTION
- 기존에는 ContextLoaderListener에서 페이지 컨트롤러 객체를 생성해서 페이지 컨트롤러뿐만 아니라 DAO를 추가하는 경우에도 ContextLoaderListener 클래스의 코드를 변경해야 하는 번거로움이 있었음
- 생성할 객체가 있다면 프로퍼티 파일(application-context.properties)에 기록하고 ContextLoaderListener는 프로퍼티 파일의 정보를 읽고 객체를 생성하도록 하여 더 이상 ContextLoaderListener를 수정하지 않도록 함